### PR TITLE
Modification proposée pour fonction updateDevicesCounter

### DIFF
--- a/core/class/linksys.class.php
+++ b/core/class/linksys.class.php
@@ -103,12 +103,10 @@ class linksys extends eqLogic {
 
     private function updateDevicesCounter() {
         $resultNetworkConnections = $this->tryGetNetworkConnections();
-        if ($resultNetworkConnections !== true) {
-            $resultDevices = $this->tryGetDevicelist();
-            if ($resultDevices !== true) {
-                log::add(__CLASS__, 'error', $this->getHumanName() . ' networkConnections:' . $resultNetworkConnections->getResult());
-                log::add(__CLASS__, 'error', $this->getHumanName() . ' devices:' . $resultDevices->getResult());
-            }
+        $resultDevices = $this->tryGetDevicelist();
+        if ($resultNetworkConnections !== true || $resultDevices !== true) {
+              log::add(__CLASS__, 'error', $this->getHumanName() . ' networkConnections:' . $resultNetworkConnections->getResult());
+              log::add(__CLASS__, 'error', $this->getHumanName() . ' devices:' . $resultDevices->getResult());
         }
     }
 


### PR DESCRIPTION
Sur routeur Velop WHW01, les fonctions tryGetNetworkConnections et tryGetDevicelist retournent tous les deux des résultats, mais seulement tryGetDevicelist retourne des résultats valables. Le code original ne permet pas d'obtenir les informations correctes car la deuxième fonction n'est jamais appelée. Je ne sais pas s'il y a des cas où la valeur correcte proviendrait de la première fonction, mais les compteurs ne sont écrasés que si la deuxième fonction retourne un résultat. Dans mon cas, alors que j'ai 13 appareils connectés, la fonction tryGetNetworkConnections ne retournait que 4 appareils tous types confondus. Le changement proposé corrige mon problème, mais je ne voudrais pas en créer un pour d'autres. Idéalement ce serait de comparer les résultats des deux fonctions et choisir celle qui donne le bon résultat, mais comment savoir lequel est le bon?